### PR TITLE
Fix memory leak when there is only one run.

### DIFF
--- a/PatienceSort.h
+++ b/PatienceSort.h
@@ -39,6 +39,10 @@ public:
         std::vector<RunPool<ValueType>*> runs;
         GenerateRuns(begin, end, runs);
         Merge(begin, runs);
+
+        // release pool memory of runs and runblocks
+        RunPool<ValueType>::Release();
+        Release();
     }
 
 
@@ -206,11 +210,6 @@ private:
         // merge the last 2 runs directly to the output
         cur_run = run_infos.begin();
         BlindMerge(arrs, begin, cur_run);
-
-        // release pool memory of runs and runblocks
-        RunPool<ValueType>::Release();
-        Release();
-
     }
 
     // Merge 2 sorted runs into a ping-pong array
@@ -295,7 +294,7 @@ private:
 
     static void Release() {
         delete[] memory_;
-        memory_ = NULL;
+        memory_ = nullptr;
     }
 
     // Fetch a new memory block from the pool
@@ -328,10 +327,10 @@ private:
 };
 
 template <class RAI>
-RunPool<typename RAI::value_type>* PatienceSorting<RAI>::memory_ = NULL;
+RunPool<typename RAI::value_type>* PatienceSorting<RAI>::memory_ = nullptr;
 
 template <class RAI>
-RunPool<typename RAI::value_type>* PatienceSorting<RAI>::next_free_ = NULL;
+RunPool<typename RAI::value_type>* PatienceSorting<RAI>::next_free_ = nullptr;
 
 template <class RAI>
 size_t PatienceSorting<RAI>::run_blocks_;

--- a/RunPool.h
+++ b/RunPool.h
@@ -14,7 +14,7 @@ struct RunBlock {
     ValueType values[kValuesPerBlock];
     bool is_front;
     RunBlock()
-            : next(NULL), prev(NULL), next_free_pos_(0), is_front(false)
+            : next(nullptr), prev(nullptr), next_free_pos_(0), is_front(false)
     {}
 
 
@@ -95,7 +95,7 @@ public:
         begin_back_ = Alloc();
         end_back_ = begin_back_;
         size_ = 0;
-        begin_front_ = end_front_ = NULL;
+        begin_front_ = end_front_ = nullptr;
         end_block_ = begin_back_;
     }
 
@@ -123,7 +123,7 @@ public:
 
 
     void AddFront(ValueType &value) {
-        if(begin_front_ == NULL) {
+        if(begin_front_ == nullptr) {
             begin_front_ = Alloc();
             begin_front_->next_free_pos_ = kValuesPerBlock - 1;
             begin_front_->is_front = true;
@@ -154,7 +154,7 @@ public:
         int size_total = size_;
         size_total += end_back_->next_free_pos_;
 
-        if(begin_front_ != NULL) {
+        if(begin_front_ != nullptr) {
             size_total +=  kValuesPerBlock - begin_front_->next_free_pos_ - 1;
         }
         return size_total;
@@ -170,7 +170,7 @@ public:
     }
 
     iterator begin() {
-        if(begin_front_ == NULL) {
+        if(begin_front_ == nullptr) {
             return iterator(begin_back_, 0);
         } else {
             return iterator(begin_front_, begin_front_->next_free_pos_ + 1);
@@ -214,6 +214,7 @@ public:
 
     static void Release() {
         delete[] memory_;
+        memory_ = nullptr;
     }
 
     static RunBlock<ValueType>* Alloc() {
@@ -239,10 +240,10 @@ private:
 };
 
 template <typename ValueType>
-RunBlock<ValueType>* RunPool<ValueType>::memory_ = NULL;
+RunBlock<ValueType>* RunPool<ValueType>::memory_ = nullptr;
 
 template <typename ValueType>
-RunBlock<ValueType>* RunPool<ValueType>::next_free_ = NULL;
+RunBlock<ValueType>* RunPool<ValueType>::next_free_ = nullptr;
 
 template <typename ValueType>
 size_t RunPool<ValueType>::mem_blocks_;


### PR DESCRIPTION
Since the memory was released at the end of Merge, it ended up never being
released when Merge exited early (which is to say when there was less than
2 runs). I moved the memory release from the end of Merge to the end of
Sort to make sure that it was always released, and also made sure that the
memory was set to nullptr when released to avoid potential problem if the
algorithm tries to release the memory twice (I also took the liberty to
change every NULL to nullptr).

To be honest, this fix isn't enough to handle memory leaks when exceptions
are thrown but at least it makes the code safer when no exception is
thrown. You should probably use std::unique_ptr or another RAII guard to
make sure that there are no memory leaks, even when an exception is
thrown.
